### PR TITLE
Add short names for Condition exports

### DIFF
--- a/src/conditions/index.js
+++ b/src/conditions/index.js
@@ -1,9 +1,9 @@
-import andCondition from './andCondition';
-import orCondition from './orCondition';
-import notCondition from './notCondition';
+import and from './andCondition';
+import or from './orCondition';
+import not from './notCondition';
 
 export default {
-  andCondition,
-  orCondition,
-  notCondition,
+  and,
+  or,
+  not,
 };


### PR DESCRIPTION
this commit allows the imports to be written as:

```
const { and, not, or } = Conditions;
```

instead of:
```
const and = Conditions.andCondition;
const not = Conditions.notCondition;
const or = Conditions.orCondition;
```